### PR TITLE
Possible broken dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,4 @@ Suggests:
     covr,
     EczemaPred (>= 0.0.0.9000)
 Remotes:  
-    github::ghurault/EczemaPred
+    github::ghurault/mbml-eczema


### PR DESCRIPTION
I think you may have renamed EczemaPred to mbml-eczema, which is causing HuraultMisc to fail to install, and as a result of this TanakaData also no longer installs.